### PR TITLE
Fix execute policy for the new Minio client/server version.

### DIFF
--- a/bmc/_policy.py
+++ b/bmc/_policy.py
@@ -20,7 +20,7 @@ def admin_policy_add(**kwargs):
       >>> r.content
       {'status': 'success', 'policy': 'admins', 'isGroup': False}
     '''
-    cmd = Command(POLICY_COMMAND + 'add {target} {name} {file}')
+    cmd = Command(POLICY_COMMAND + 'create {target} {name} {file}')
 
     return cmd(**kwargs)
 
@@ -34,7 +34,7 @@ def admin_policy_remove(**kwargs):
       >>> r.content
       {'status': 'success', 'policy': 'admins', 'isGroup': False}
     '''
-    cmd = Command(POLICY_COMMAND + 'remove {target} {name}')
+    cmd = Command(POLICY_COMMAND + 'detach {target} {name}')
 
     return cmd(**kwargs)
 
@@ -93,8 +93,8 @@ def admin_policy_set(**kwargs):
         raise KeyError('Only one of user or group arguments can be set.')
 
     if 'group' in kwargs:
-        cmd = Command(POLICY_COMMAND + 'set {target} {name} group={group}')
+        cmd = Command(POLICY_COMMAND + 'attach {target} {name} --group {group}')
     else:
-        cmd = Command(POLICY_COMMAND + 'set {target} {name} user={user}')
+        cmd = Command(POLICY_COMMAND + 'attach {target} {name} --user {user}')
 
     return cmd(**kwargs)


### PR DESCRIPTION
**Description**

- Replace `add` with `create` when creating a new policy.
- Replace `remove` with `detach` when removing a policy.
- Replace `set` with `attach` when attaching a polity to a group or user.

This is necessary when using a Minio after version: `RELEASE.2023-03-20T17-17-53Z`

More information about this: https://min.io/docs/minio/linux/reference/minio-mc-admin/mc-admin-policy.html